### PR TITLE
Tests failure fix

### DIFF
--- a/django_analyses/models/input/definitions/input_definition.py
+++ b/django_analyses/models/input/definitions/input_definition.py
@@ -37,9 +37,12 @@ class InputDefinition(models.Model):
         ordering = ("key",)
 
     def __str__(self) -> str:
-        input_type = self.input_class.__name__
-        input_type = input_type.replace("Input", "")
-        return f"{self.key:<50}\t{input_type:<30}"
+        try:
+            input_type = self.input_class.__name__.replace("Input", "")
+        except AttributeError:
+            return self.key
+        else:
+            return f"{self.key:<50}\t{input_type:<30}"
 
     def check_input_class_definition(self) -> None:
         input_base_name = f"{Input.__module__}.{Input.__name__}"

--- a/django_analyses/models/output/definitions/output_definition.py
+++ b/django_analyses/models/output/definitions/output_definition.py
@@ -17,9 +17,12 @@ class OutputDefinition(models.Model):
         ordering = ("key",)
 
     def __str__(self) -> str:
-        output_type = self.output_class.__name__
-        output_type = output_type.replace("Output", "")
-        return f"{self.key:<50}\t{output_type:<30}"
+        try:
+            output_type = self.output_class.__name__.replace("Output", "")
+        except AttributeError:
+            return self.key
+        else:
+            return f"{self.key:<50}\t{output_type:<30}"
 
     def check_output_class_definition(self) -> None:
         output_base_name = f"{Output.__module__}.{Output.__name__}"

--- a/docs/source/user_guide/pipeline_generation.rst
+++ b/docs/source/user_guide/pipeline_generation.rst
@@ -90,8 +90,8 @@ And then we can lay down the pipe:
     >>> from django_analyses.models import Pipe
 
     # Querying the required InputDefinition instances
-    >>> square_output = exponent.output_definitions.get(key="result")
-    >>> raise_3_input = exponent.input_definitions.get(key="exponent")
+    >>> square_output = exponent_calculation.output_definitions.get(key="result")
+    >>> raise_3_input = exponent_calculation.input_definitions.get(key="exponent")
 
     # Create the pipe
     >>> pipe = Pipe.objects.create(


### PR DESCRIPTION
Fixed tests failure caused by changing the InputDefinition and OutputDefinition string representations.