### PR TITLE
Fixed #43.

### DIFF
--- a/django_analyses/models/managers/pipe.py
+++ b/django_analyses/models/managers/pipe.py
@@ -40,6 +40,7 @@ class PipeManager(models.Manager):
             destination=destination,
             base_destination_port=destination_port,
             destination_run_index=destination_run_index,
+            index=definition.get("index"),
         )
 
     def from_list(self, pipeline, definitions: list):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -171,7 +171,7 @@ PIPELINES = [
                 "destination": NORM_NODE,
                 "destination_run_index": 0,
                 "destination_port": "x",
-                "index": 0,
+                "index": 1,
             },
             {
                 "source": ADDITION_NODE,
@@ -180,7 +180,7 @@ PIPELINES = [
                 "destination": NORM_NODE,
                 "destination_run_index": 0,
                 "destination_port": "x",
-                "index": 1,
+                "index": 0,
             },
         ],
     },

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -242,3 +242,18 @@ class PipelineRunnerTestCase(TestCase):
         norm_result = norm_results[0].get_output("norm")
         norm_expected = 6.082762530298219
         self.assertAlmostEqual(norm_result, norm_expected)
+
+    def test_listinput_indices(self):
+        pipeline = Pipeline.objects.get(title="Test Pipeline 1")
+        runner = PipelineRunner(pipeline=pipeline, quiet=False)
+        square_node = Node.objects.get(
+            analysis_version=self.power, configuration={"exponent": 2}
+        )
+        inputs = {
+            self.addition_node: [{"x": 1, "y": 1}, {"x": 1, "y": 1}],
+            square_node: [{"base": 1}],
+        }
+        results = runner.run(inputs=inputs)
+        norm_run = results[self.norm_node][0]
+        x = norm_run.input_configuration["x"]
+        self.assertListEqual(x, [6.0, 1.0])


### PR DESCRIPTION
Added the `index` attribute to the `Pipe` manager's `from_dict()` method. 