### PR TITLE
Fixed run delete, resovles #41.

### DIFF
--- a/django_analyses/__init__.py
+++ b/django_analyses/__init__.py
@@ -1,3 +1,4 @@
 """
 A reusable Django app to manage analyses and pipelines.
 """
+default_app_config = "django_analyses.apps.DjangoAnalysesConfig"

--- a/django_analyses/apps.py
+++ b/django_analyses/apps.py
@@ -21,8 +21,19 @@ class DjangoAnalysesConfig(AppConfig):
     * `AppConfig attributes`_
 
     .. _AppConfig attributes:
-       https://docs.djangoproject.com/en/3.0/ref/applications/#configurable-attributes
+    https://docs.djangoproject.com/en/3.0/ref/applications/#configurable-attributes
     """
 
     #: Full Python path to the application.
     name = "django_analyses"
+
+    def ready(self):
+        """
+        Loads the app's signals.
+
+        References
+        ----------
+        * :meth:`~django.apps.AppConfig.ready`
+        """
+
+        import django_analyses.signals  # noqa: F401

--- a/django_analyses/models/run.py
+++ b/django_analyses/models/run.py
@@ -3,8 +3,6 @@ Definition of the :class:`~django_analyses.models.run.Run` class.
 
 """
 
-import shutil
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -50,24 +48,6 @@ class Run(TimeStampedModel):
         """
 
         return f"#{self.id} {self.analysis_version} run from {self.created}"
-
-    def delete(self, *args, **kwargs) -> tuple:
-        """
-        `Overrides
-        <https://docs.djangoproject.com/en/3.0/topics/db/models/#overriding-model-methods>`_
-        the :meth:`~django.db.models.Model.delete` method to also remove
-        the run's directory from
-        `media <https://docs.djangoproject.com/en/3.0/topics/files/>`_.
-
-        Returns
-        -------
-        tuple
-            (number of deleted objects, dictionary of number by type)
-        """
-
-        if self.path:
-            shutil.rmtree(self.path)
-        return super().delete(*args, **kwargs)
 
     def get_input_set(self) -> InheritanceQuerySet:
         """

--- a/django_analyses/signals.py
+++ b/django_analyses/signals.py
@@ -1,0 +1,27 @@
+"""
+Signal receivers.
+
+References
+----------
+* Signals_
+
+.. _Signals:
+   https://docs.djangoproject.com/en/3.0/ref/signals/
+"""
+
+import shutil
+
+from django.db.models import Model
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from django_analyses.models.run import Run
+
+
+@receiver(pre_delete, sender=Run)
+def run_pre_delete_receiver(
+    sender: Model, instance: Run, using, **kwargs
+) -> None:
+    print("got signal")
+    if instance.path:
+        print("deleting path")
+        shutil.rmtree(instance.path)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -18,7 +18,7 @@ ANALYSES = [
         "versions": [
             {
                 "title": "1.0",
-                "description": "Simple addition of two floating point numbers.",
+                "description": "Simple addition of two floating point numbers.",  # noqa: E501
                 "run_method_key": "calculate",
                 "input": {
                     "x": {
@@ -85,7 +85,7 @@ ANALYSES = [
                     "x": {
                         "type": ListInputDefinition,
                         "element_type": "FLT",
-                        "description": "Input array. If axis is None, x must be 1-D or 2-D.",
+                        "description": "Input array. If axis is None, x must be 1-D or 2-D.",  # noqa: E501
                         "required": True,
                         "is_configuration": False,
                     },


### PR DESCRIPTION
Replaced `delete()` method override with a [`pre_delete()`](https://docs.djangoproject.com/en/3.1/ref/signals/#pre-delete) signal.